### PR TITLE
Added `docker_compose_binary` rule

### DIFF
--- a/docker_compose/BUILD.bazel
+++ b/docker_compose/BUILD.bazel
@@ -3,9 +3,11 @@ load("//docker_compose/private:toolchain.bzl", "current_docker_compose_toolchain
 
 exports_files([
     "defs.bzl",
+    "docker_compose_binary.bzl",
+    "docker_compose_config.bzl",
     "docker_compose_test.bzl",
-    "docker_compose_yaml.bzl",
     "docker_compose_toolchain.bzl",
+    "docker_compose_yaml.bzl",
 ])
 
 toolchain_type(
@@ -29,10 +31,26 @@ bzl_library(
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],
     deps = [
+        ":docker_compose_binary_bzl",
+        ":docker_compose_config_bzl",
         ":docker_compose_test_bzl",
         ":docker_compose_toolchain_bzl",
         ":docker_compose_yaml_bzl",
     ],
+)
+
+bzl_library(
+    name = "docker_compose_binary_bzl",
+    srcs = ["docker_compose_binary.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["//docker_compose/private:bzl_lib"],
+)
+
+bzl_library(
+    name = "docker_compose_config_bzl",
+    srcs = ["docker_compose_config.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["//docker_compose/private:bzl_lib"],
 )
 
 bzl_library(

--- a/docker_compose/defs.bzl
+++ b/docker_compose/defs.bzl
@@ -1,6 +1,14 @@
 """# Docker Compose"""
 
 load(
+    ":docker_compose_binary.bzl",
+    _docker_compose_binary = "docker_compose_binary",
+)
+load(
+    ":docker_compose_config.bzl",
+    _docker_compose_config = "docker_compose_config",
+)
+load(
     ":docker_compose_test.bzl",
     _docker_compose_test = "docker_compose_test",
 )
@@ -13,6 +21,8 @@ load(
     _docker_compose_yaml = "docker_compose_yaml",
 )
 
+docker_compose_binary = _docker_compose_binary
+docker_compose_config = _docker_compose_config
 docker_compose_toolchain = _docker_compose_toolchain
 docker_compose_test = _docker_compose_test
 docker_compose_yaml = _docker_compose_yaml

--- a/docker_compose/docker_compose_binary.bzl
+++ b/docker_compose/docker_compose_binary.bzl
@@ -1,0 +1,8 @@
+"""# docker_compose_binary"""
+
+load(
+    "//docker_compose/private:docker_compose.bzl",
+    _docker_compose_binary = "docker_compose_binary",
+)
+
+docker_compose_binary = _docker_compose_binary

--- a/docker_compose/docker_compose_config.bzl
+++ b/docker_compose/docker_compose_config.bzl
@@ -1,0 +1,8 @@
+"""# docker_compose_config"""
+
+load(
+    "//docker_compose/private:docker_compose.bzl",
+    _docker_compose_config = "docker_compose_config",
+)
+
+docker_compose_config = _docker_compose_config

--- a/docker_compose/private/docker_compose.bzl
+++ b/docker_compose/private/docker_compose.bzl
@@ -3,6 +3,48 @@
 load(":image_utils.bzl", "ImageLoadRepositoryInfo", "image_load_repository_aspect")
 load(":toolchain.bzl", "TOOLCHAIN_TYPE")
 
+def docker_compose_config(
+        services = {},
+        networks = {},
+        volumes = {},
+        configs = {},
+        secrets = {}):
+    """Encode a docker-compose configuration as a JSON string.
+
+    Parameters mirror the top-level keys of the
+    [Compose Specification](https://docs.docker.com/reference/compose-file/).
+    The returned string is suitable for passing to the `config` attribute
+    of `docker_compose_yaml`.
+
+    Args:
+        services: A dict mapping service names to their configuration dicts.
+            Each value follows the Compose `services.<name>` schema (image,
+            ports, environment, volumes, depends_on, etc.).
+        networks: A dict mapping network names to their configuration dicts.
+            Follows the Compose `networks.<name>` schema.
+        volumes: A dict mapping volume names to their configuration dicts.
+            Follows the Compose `volumes.<name>` schema.
+        configs: A dict mapping config names to their configuration dicts.
+            Follows the Compose `configs.<name>` schema.
+        secrets: A dict mapping secret names to their configuration dicts.
+            Follows the Compose `secrets.<name>` schema.
+
+    Returns:
+        A JSON-encoded string representing the docker-compose configuration.
+    """
+    compose = {}
+    if services:
+        compose["services"] = services
+    if networks:
+        compose["networks"] = networks
+    if volumes:
+        compose["volumes"] = volumes
+    if configs:
+        compose["configs"] = configs
+    if secrets:
+        compose["secrets"] = secrets
+    return json.encode(compose)
+
 DockerComposeYamlInfo = provider(
     doc = """\
 Provides information about a resolved docker-compose YAML configuration.
@@ -137,7 +179,19 @@ def _collect_images(*, yamls, images):
 def _docker_compose_yaml_impl(ctx):
     toolchain = ctx.toolchains[TOOLCHAIN_TYPE]
 
+    if not ctx.attr.yamls and not ctx.attr.config:
+        fail("At least one of `yamls` or `config` must be provided")
+
     yamls = _collect_yamls(yamls = ctx.attr.yamls)
+
+    extra_yaml_files = []
+    if ctx.attr.config:
+        config_file = ctx.actions.declare_file("{}_config.json".format(ctx.label.name))
+        ctx.actions.write(
+            output = config_file,
+            content = ctx.attr.config,
+        )
+        extra_yaml_files.append(config_file)
 
     images = _collect_images(yamls = ctx.attr.yamls, images = ctx.attr.images)
 
@@ -155,7 +209,7 @@ def _docker_compose_yaml_impl(ctx):
 
     _docker_compose_yaml_action(
         ctx = ctx,
-        yamls = yamls.to_list(),
+        yamls = yamls.to_list() + extra_yaml_files,
         output = output,
         out_lock = lock,
         toolchain = toolchain,
@@ -178,11 +232,16 @@ def _docker_compose_yaml_impl(ctx):
 
 docker_compose_yaml = rule(
     doc = """\
-Merges multiple docker-compose YAML files and validates image references.
+Merges docker-compose configurations and validates image references.
 
 This rule uses `docker-compose config` to merge one or more docker-compose YAML files
-into a single, canonical configuration. It also validates that all images referenced
-in the configuration have corresponding loader targets specified in the `images` attribute.
+(and/or an inline Starlark configuration) into a single, canonical configuration. It
+also validates that all images referenced in the configuration have corresponding loader
+targets specified in the `images` attribute.
+
+At least one of `yamls` or `config` must be provided. When both are given, they are
+merged together using `docker-compose config` (the `config` JSON is applied on top of
+the YAML files).
 
 A lock file is generated containing a mapping of image tags to their content digests,
 which can be used to verify that the correct images are loaded at runtime.
@@ -194,7 +253,7 @@ Supported image loader types:
 | [oci_load](https://github.com/bazel-contrib/rules_oci/blob/main/docs/load.md#oci_load) | rules_oci |
 | [image_load](https://github.com/bazel-contrib/rules_img/blob/main/docs/load.md#image_load) | rules_img |
 
-Example:
+Example with YAML files:
 ```python
 load("@rules_docker_compose//docker_compose:docker_compose_yaml.bzl", "docker_compose_yaml")
 load("@rules_oci//oci:defs.bzl", "oci_load")
@@ -211,21 +270,48 @@ docker_compose_yaml(
     images = [":my_image.load"],
 )
 ```
+
+Example with inline Starlark config:
+```python
+load("@rules_docker_compose//docker_compose:docker_compose_config.bzl", "docker_compose_config")
+load("@rules_docker_compose//docker_compose:docker_compose_yaml.bzl", "docker_compose_yaml")
+load("@rules_oci//oci:defs.bzl", "oci_load")
+
+oci_load(
+    name = "nginx.load",
+    image = ":nginx",
+    repo_tags = ["my-app/nginx:latest"],
+)
+
+docker_compose_yaml(
+    name = "compose",
+    config = docker_compose_config(
+        services = {
+            "web": {
+                "image": "my-app/nginx:latest",
+                "ports": ["8080:80"],
+            },
+        },
+    ),
+    images = [":nginx.load"],
+)
+```
 """,
     implementation = _docker_compose_yaml_impl,
     attrs = {
+        "config": attr.string(
+            doc = "A JSON-encoded docker-compose configuration string. Use `docker_compose_config()` to produce this value from structured Starlark dicts. Can be used alone or combined with `yamls`.",
+        ),
         "images": attr.label_list(
-            doc = "Image loader targets that provide the container images referenced in the YAML files. Each image referenced in the docker-compose YAML must have a corresponding loader target. See the rule documentation for supported loader types.",
+            doc = "Image loader targets that provide the container images referenced in the configuration. Each image referenced in the docker-compose config must have a corresponding loader target. See the rule documentation for supported loader types.",
             aspects = [image_load_repository_aspect],
         ),
         "out": attr.output(
             doc = "Optional output filename for the merged docker-compose YAML. Defaults to `{name}/docker-compose.yaml`.",
         ),
         "yamls": attr.label_list(
-            doc = "One or more docker-compose YAML files to merge. Files are merged in order using `docker-compose config`.",
+            doc = "One or more docker-compose YAML files to merge. Files are merged in order using `docker-compose config`. At least one of `yamls` or `config` must be provided.",
             allow_files = [".yaml", ".yml"],
-            mandatory = True,
-            allow_empty = False,
         ),
         "_merger": attr.label(
             cfg = "exec",
@@ -233,6 +319,134 @@ docker_compose_yaml(
             default = Label("//docker_compose/private/merger"),
         ),
     },
+    toolchains = [TOOLCHAIN_TYPE],
+)
+
+def _docker_compose_binary_impl(ctx):
+    toolchain = ctx.toolchains[TOOLCHAIN_TYPE]
+
+    info = ctx.attr.yaml[DockerComposeYamlInfo]
+    yaml = info.yaml
+    lock = info.yaml_lock
+
+    images = _collect_images(yamls = [ctx.attr.yaml], images = ctx.attr.images)
+
+    is_windows = ctx.executable._launcher.basename.endswith(".exe")
+    executable = ctx.actions.declare_file("{}{}".format(
+        ctx.label.name,
+        ".exe" if is_windows else "",
+    ))
+
+    ctx.actions.symlink(
+        output = executable,
+        target_file = ctx.executable._launcher,
+        is_executable = True,
+    )
+
+    args_file = ctx.actions.declare_file("{0}_data/{0}.args.txt".format(ctx.label.name))
+    runfiles = ctx.runfiles(files = [args_file, yaml, lock], transitive_files = toolchain.all_files)
+
+    args = ctx.actions.args()
+    args.set_param_file_format("multiline")
+    args.add("-docker-compose", _rlocationpath(toolchain.docker_compose, ctx.workspace_name))
+    args.add("-yaml", _rlocationpath(yaml, ctx.workspace_name))
+
+    for image in images:
+        image_info = image[ImageLoadRepositoryInfo]
+        runfiles = runfiles.merge(image_info.loader_runfiles)
+        args.add("-loader", _rlocationpath(image_info.loader, ctx.workspace_name))
+
+    ctx.actions.write(
+        output = args_file,
+        content = args,
+    )
+
+    workspace_name = ctx.label.workspace_name
+    if not workspace_name:
+        workspace_name = ctx.workspace_name
+
+    return [
+        DefaultInfo(
+            files = depset([executable]),
+            runfiles = runfiles,
+            executable = executable,
+        ),
+        RunEnvironmentInfo(
+            environment = {
+                "REPOSITORY_NAME": workspace_name,
+                "RULES_DOCKER_COMPOSE_ARGS_FILE": _rlocationpath(args_file, workspace_name),
+            },
+        ),
+    ]
+
+docker_compose_binary = rule(
+    doc = """\
+Creates a runnable target for invoking docker-compose with a generated configuration.
+
+This rule consumes a `docker_compose_yaml` target and produces an executable that:
+
+1. Loads container images into Docker using the specified loader targets
+2. Runs `docker-compose -f <yaml> <args...>` forwarding all command-line arguments
+
+Use this rule when you need to interactively manage docker-compose services
+(e.g. `bazel run :compose -- up -d`, `bazel run :compose -- down`).
+
+Supported image loader types:
+
+| Loader | Source |
+|--------|--------|
+| [oci_load](https://github.com/bazel-contrib/rules_oci/blob/main/docs/load.md#oci_load) | rules_oci |
+| [image_load](https://github.com/bazel-contrib/rules_img/blob/main/docs/load.md#image_load) | rules_img |
+
+Example:
+```python
+load("@rules_docker_compose//docker_compose:defs.bzl", "docker_compose_binary", "docker_compose_yaml")
+load("@rules_oci//oci:defs.bzl", "oci_load")
+
+oci_load(
+    name = "my_service.load",
+    image = ":my_service",
+    repo_tags = ["my-service:latest"],
+)
+
+docker_compose_yaml(
+    name = "compose_yaml",
+    yamls = ["docker-compose.yaml"],
+    images = [":my_service.load"],
+)
+
+docker_compose_binary(
+    name = "compose",
+    yaml = ":compose_yaml",
+    images = [":my_service.load"],
+)
+```
+
+Then run with:
+```bash
+bazel run :compose -- up -d
+bazel run :compose -- down
+bazel run :compose -- ps
+```
+""",
+    implementation = _docker_compose_binary_impl,
+    attrs = {
+        "images": attr.label_list(
+            doc = "Image loader targets that provide the container images for the docker-compose services. Each image will be loaded into Docker before docker-compose is invoked. See the rule documentation for supported loader types.",
+            aspects = [image_load_repository_aspect],
+        ),
+        "yaml": attr.label(
+            doc = "A `docker_compose_yaml` target providing the merged docker-compose configuration.",
+            mandatory = True,
+            providers = [DockerComposeYamlInfo],
+        ),
+        "_launcher": attr.label(
+            cfg = "exec",
+            executable = True,
+            default = Label("//docker_compose/private/launcher"),
+        ),
+    },
+    executable = True,
     toolchains = [TOOLCHAIN_TYPE],
 )
 

--- a/docker_compose/private/docker_compose.bzl
+++ b/docker_compose/private/docker_compose.bzl
@@ -55,6 +55,7 @@ It can be consumed by `docker_compose_test` or other rules that need to work
 with docker-compose configurations.
 """,
     fields = {
+        "data": "depset[File]: Additional data files referenced by the configuration (env_file, configs, secrets, bind-mount sources).",
         "images": "depset[File]: The image loader executables for each image referenced in the yaml.",
         "yaml": "File: The merged docker-compose YAML file.",
         "yaml_deps": "depset[File]: All files which contributed to the merged yaml (input yamls and image manifests).",
@@ -139,7 +140,9 @@ def _docker_compose_yaml_action(
         out_lock,
         toolchain,
         image_manifests = [],
-        image_inputs = []):
+        image_inputs = [],
+        data_inputs = [],
+        config_file = None):
     # Sanitize label for project name: replace @ with AT, + with -, / with _, : with __
     project_name = str(ctx.label).replace("@", "0").replace("+", "-").replace("/", "_").replace(":", "__")
 
@@ -156,11 +159,33 @@ def _docker_compose_yaml_action(
         # Add the single_image_manifest to args
         args.add("-image_manifest", manifest)
 
+    extra_inputs = []
+    if data_inputs:
+        data_manifest = {}
+        for f in data_inputs:
+            f_rlocation = _rlocationpath(f, ctx.workspace_name)
+            data_manifest[f.path] = f_rlocation
+
+            if config_file:
+                bin_prefix = config_file.path[:-len(config_file.short_path)]
+                config_relative = bin_prefix + f.short_path
+                if config_relative != f.path:
+                    data_manifest[config_relative] = f_rlocation
+
+        data_manifest_file = ctx.actions.declare_file("{}_data_manifest.json".format(ctx.label.name))
+        ctx.actions.write(
+            output = data_manifest_file,
+            content = json.encode(data_manifest),
+        )
+        args.add("-data-manifest", data_manifest_file)
+        args.add("-output-rlocationpath", _rlocationpath(output, ctx.workspace_name))
+        extra_inputs.append(data_manifest_file)
+
     ctx.actions.run(
         mnemonic = "DockerComposeYamlConfig",
         executable = ctx.executable._merger,
         arguments = [args],
-        inputs = depset(yamls + image_inputs + image_manifests),
+        inputs = depset(yamls + image_inputs + image_manifests + data_inputs + extra_inputs),
         outputs = [output, out_lock],
         tools = toolchain.all_files,
     )
@@ -185,6 +210,7 @@ def _docker_compose_yaml_impl(ctx):
     yamls = _collect_yamls(yamls = ctx.attr.yamls)
 
     extra_yaml_files = []
+    config_file = None
     if ctx.attr.config:
         config_file = ctx.actions.declare_file("{}_config.json".format(ctx.label.name))
         ctx.actions.write(
@@ -192,6 +218,10 @@ def _docker_compose_yaml_impl(ctx):
             content = ctx.attr.config,
         )
         extra_yaml_files.append(config_file)
+
+    data_files = []
+    for target in ctx.attr.data:
+        data_files.extend(target[DefaultInfo].files.to_list())
 
     images = _collect_images(yamls = ctx.attr.yamls, images = ctx.attr.images)
 
@@ -215,18 +245,21 @@ def _docker_compose_yaml_impl(ctx):
         toolchain = toolchain,
         image_manifests = image_manifests,
         image_inputs = image_inputs,
+        data_inputs = data_files,
+        config_file = config_file,
     )
 
     return [
         DefaultInfo(
             files = depset([output]),
-            runfiles = ctx.runfiles(files = [output]),
+            runfiles = ctx.runfiles(files = [output] + data_files),
         ),
         DockerComposeYamlInfo(
             yaml = output,
             yaml_lock = lock,
             yaml_deps = yamls,
             images = ctx.attr.images,
+            data = depset(data_files),
         ),
     ]
 
@@ -302,6 +335,10 @@ docker_compose_yaml(
         "config": attr.string(
             doc = "A JSON-encoded docker-compose configuration string. Use `docker_compose_config()` to produce this value from structured Starlark dicts. Can be used alone or combined with `yamls`.",
         ),
+        "data": attr.label_list(
+            doc = "Additional files referenced by the docker-compose configuration (e.g. env_file, config files, secret files, bind-mount sources). These are made available during the merge action and propagated to consuming rules for runtime availability.",
+            allow_files = True,
+        ),
         "images": attr.label_list(
             doc = "Image loader targets that provide the container images referenced in the configuration. Each image referenced in the docker-compose config must have a corresponding loader target. See the rule documentation for supported loader types.",
             aspects = [image_load_repository_aspect],
@@ -345,6 +382,9 @@ def _docker_compose_binary_impl(ctx):
 
     args_file = ctx.actions.declare_file("{0}_data/{0}.args.txt".format(ctx.label.name))
     runfiles = ctx.runfiles(files = [args_file, yaml, lock], transitive_files = toolchain.all_files)
+
+    if info.data:
+        runfiles = runfiles.merge(ctx.runfiles(transitive_files = info.data))
 
     args = ctx.actions.args()
     args.set_param_file_format("multiline")
@@ -538,10 +578,12 @@ def _docker_compose_test_impl(ctx):
 
     images = _collect_images(yamls = ctx.attr.yamls, images = ctx.attr.images)
 
+    data_from_yaml = None
     if len(ctx.attr.yamls) == 1 and DockerComposeYamlInfo in ctx.attr.yamls[0]:
         info = ctx.attr.yamls[0][DockerComposeYamlInfo]
         yaml = info.yaml
         lock = info.yaml_lock
+        data_from_yaml = info.data
     else:
         yamls = _collect_yamls(yamls = ctx.attr.yamls)
 
@@ -581,6 +623,9 @@ def _docker_compose_test_impl(ctx):
 
     args_file = ctx.actions.declare_file("{0}_data/{0}.args.txt".format(ctx.label.name))
     runfiles = ctx.runfiles(files = [args_file, yaml, lock], transitive_files = toolchain.all_files)
+
+    if data_from_yaml:
+        runfiles = runfiles.merge(ctx.runfiles(transitive_files = data_from_yaml))
 
     args = ctx.actions.args()
     args.set_param_file_format("multiline")

--- a/docker_compose/private/launcher/BUILD.bazel
+++ b/docker_compose/private/launcher/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_binary")
+
+go_binary(
+    name = "launcher",
+    srcs = ["launcher.go"],
+    visibility = ["//visibility:public"],
+    deps = ["@rules_go//go/runfiles"],
+)

--- a/docker_compose/private/launcher/launcher.go
+++ b/docker_compose/private/launcher/launcher.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/bazelbuild/rules_go/go/runfiles"
+)
+
+func debugLog(format string, args ...interface{}) {
+	if os.Getenv("RULES_DOCKER_COMPOSE_DEBUG") != "" {
+		fmt.Fprintf(os.Stderr, "[DEBUG] "+format+"\n", args...)
+	}
+}
+
+type Args struct {
+	DockerCompose string
+	Yaml          string
+	Loaders       []string
+}
+
+func parseArgs() (*Args, error) {
+	argsFile := os.Getenv("RULES_DOCKER_COMPOSE_ARGS_FILE")
+	if argsFile == "" {
+		return nil, fmt.Errorf("RULES_DOCKER_COMPOSE_ARGS_FILE environment variable is not set")
+	}
+
+	rf, err := runfiles.New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize runfiles: %v", err)
+	}
+
+	resolvedArgsFile, err := rf.Rlocation(argsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve runfiles path %s: %v", argsFile, err)
+	}
+
+	file, err := os.Open(resolvedArgsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open args file %s: %v", resolvedArgsFile, err)
+	}
+	defer file.Close()
+
+	var argLines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			argLines = append(argLines, parts[0], strings.Join(parts[1:], " "))
+		} else {
+			argLines = append(argLines, parts[0])
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading args file: %v", err)
+	}
+
+	fs := flag.NewFlagSet("launcher", flag.ContinueOnError)
+	args := &Args{}
+
+	fs.StringVar(&args.DockerCompose, "docker-compose", "", "Path to docker-compose binary")
+	fs.StringVar(&args.Yaml, "yaml", "", "Path to docker-compose yaml file")
+
+	var loaders []string
+	fs.Func("loader", "Image loader to run before docker-compose (can be specified multiple times)", func(value string) error {
+		loaders = append(loaders, value)
+		return nil
+	})
+
+	if err := fs.Parse(argLines); err != nil {
+		return nil, fmt.Errorf("failed to parse args: %v", err)
+	}
+
+	// Resolve runfiles paths
+	if args.DockerCompose != "" {
+		resolved, err := rf.Rlocation(args.DockerCompose)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve docker-compose path %s: %v", args.DockerCompose, err)
+		}
+		args.DockerCompose = resolved
+	}
+	if args.Yaml != "" {
+		resolved, err := rf.Rlocation(args.Yaml)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve yaml path %s: %v", args.Yaml, err)
+		}
+		args.Yaml = resolved
+	}
+	for i, loader := range loaders {
+		resolved, err := rf.Rlocation(loader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve loader path %s: %v", loader, err)
+		}
+		loaders[i] = resolved
+	}
+	args.Loaders = loaders
+
+	if args.DockerCompose == "" {
+		return nil, fmt.Errorf("missing required flag: -docker-compose")
+	}
+	if args.Yaml == "" {
+		return nil, fmt.Errorf("missing required flag: -yaml")
+	}
+
+	return args, nil
+}
+
+func main() {
+	debugLog("Starting launcher")
+	args, err := parseArgs()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing args: %v\n", err)
+		os.Exit(1)
+	}
+	debugLog("Parsed args: docker-compose=%s, yaml=%s, loaders=%v", args.DockerCompose, args.Yaml, args.Loaders)
+
+	// Load images
+	if len(args.Loaders) > 0 {
+		debugLog("Running %d image loader(s)", len(args.Loaders))
+		for i, loader := range args.Loaders {
+			debugLog("Running loader %d: %s", i+1, loader)
+			loaderCmd := exec.Command(loader)
+			loaderCmd.Stdout = os.Stderr
+			loaderCmd.Stderr = os.Stderr
+			if err := loaderCmd.Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error running image loader %s: %v\n", loader, err)
+				os.Exit(1)
+			}
+			debugLog("Loader %d completed successfully", i+1)
+		}
+	}
+
+	// Build the docker-compose command: docker-compose -f <yaml> <user args...>
+	execArgs := []string{args.DockerCompose, "-f", args.Yaml}
+	execArgs = append(execArgs, os.Args[1:]...)
+
+	debugLog("Exec: %v", execArgs)
+	if err := syscall.Exec(args.DockerCompose, execArgs, os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr, "Error exec'ing docker-compose: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/docker_compose/private/merger/merger.go
+++ b/docker_compose/private/merger/merger.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/periareon/rules_docker_compose/docker_compose/private/digest"
@@ -25,14 +26,66 @@ func normalizeLineEndings(data []byte) []byte {
 	return []byte(strings.ReplaceAll(string(data), "\r\n", "\n"))
 }
 
+// relativizePaths rewrites absolute execroot paths in the merged YAML to paths
+// relative to the output file's runfiles location. It uses a manifest that maps
+// each data file's execpath to its rlocationpath, ensuring correctness across the
+// execroot-to-runfiles boundary (where bazel-out/<config>/bin/ is stripped).
+func relativizePaths(yamlContent []byte, execrootPrefix string,
+	dataManifest map[string]string, outputRlocationDir string) []byte {
+
+	if execrootPrefix == "" || len(dataManifest) == 0 {
+		return yamlContent
+	}
+	execrootPrefix = filepath.Clean(execrootPrefix)
+	if !strings.HasSuffix(execrootPrefix, string(filepath.Separator)) {
+		execrootPrefix += string(filepath.Separator)
+	}
+	content := string(yamlContent)
+	escapedPrefix := regexp.QuoteMeta(execrootPrefix)
+	re := regexp.MustCompile(escapedPrefix + `([^:\s"'\n]*)`)
+	return []byte(re.ReplaceAllStringFunc(content, func(match string) string {
+		execpath := strings.TrimPrefix(match, execrootPrefix)
+
+		rlocationpath, ok := dataManifest[execpath]
+		if !ok {
+			debugLog("Path not in data manifest, leaving unchanged: %s", execpath)
+			return match
+		}
+
+		relPath, err := filepath.Rel(outputRlocationDir, rlocationpath)
+		if err != nil {
+			debugLog("Failed to relativize path %s: %v", execpath, err)
+			return match
+		}
+		relPath = filepath.ToSlash(relPath)
+		debugLog("Relativized path: %s -> %s (rlocation: %s)", execpath, relPath, rlocationpath)
+		return relPath
+	}))
+}
+
+// loadDataManifest reads a JSON file mapping execpaths to rlocationpaths.
+func loadDataManifest(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read data manifest %s: %v", path, err)
+	}
+	var manifest map[string]string
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to parse data manifest %s: %v", path, err)
+	}
+	return manifest, nil
+}
+
 type Args struct {
-	DockerCompose  string
-	Output         string
-	OutputLock     string
-	ProjectName    string
-	DigestMode     string // "oci" or "docker"
-	Files          []string
-	ImageManifests []string
+	DockerCompose      string
+	Output             string
+	OutputLock         string
+	ProjectName        string
+	DigestMode         string // "oci" or "docker"
+	DataManifest       string
+	OutputRlocationpath string
+	Files              []string
+	ImageManifests     []string
 }
 
 type ImageManifest struct {
@@ -63,6 +116,8 @@ func parseArgs() (*Args, error) {
 	flag.StringVar(&args.OutputLock, "output-lock", "", "Path to output lock file (JSON mapping image tags to digests)")
 	flag.StringVar(&args.ProjectName, "project-name", "", "Project name for docker-compose")
 	flag.StringVar(&args.DigestMode, "digest-mode", "oci", "Digest mode: 'oci' uses manifest digest, 'docker' uses config digest (for docker load compatibility)")
+	flag.StringVar(&args.DataManifest, "data-manifest", "", "Path to JSON manifest mapping data file execpaths to rlocationpaths")
+	flag.StringVar(&args.OutputRlocationpath, "output-rlocationpath", "", "Rlocationpath of the output YAML file (for computing relative paths)")
 	var files flagArray
 	flag.Var(&files, "file", "Docker compose yaml file to merge (can be specified multiple times)")
 	var imageManifests flagArray
@@ -419,6 +474,24 @@ func main() {
 		os.Exit(1)
 	}
 	debugLog("docker-compose config completed, output size: %d bytes", len(output))
+
+	// Rewrite absolute execroot paths to relative paths so the YAML works from runfiles at runtime.
+	// Uses a manifest that maps data file execpaths to rlocationpaths for correctness.
+	if args.DataManifest != "" && args.OutputRlocationpath != "" {
+		dataManifest, err := loadDataManifest(args.DataManifest)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading data manifest: %v\n", err)
+			os.Exit(1)
+		}
+		debugLog("Loaded data manifest with %d entries", len(dataManifest))
+
+		execrootPrefix := ""
+		if cwd, err := os.Getwd(); err == nil {
+			execrootPrefix = filepath.Clean(cwd) + string(filepath.Separator)
+		}
+		outputRlocationDir := filepath.Dir(args.OutputRlocationpath)
+		output = relativizePaths(output, execrootPrefix, dataManifest, outputRlocationDir)
+	}
 
 	// Generate lock file if requested
 	if args.OutputLock != "" {

--- a/docker_compose/private/merger/merger.go
+++ b/docker_compose/private/merger/merger.go
@@ -30,21 +30,30 @@ func normalizeLineEndings(data []byte) []byte {
 // relative to the output file's runfiles location. It uses a manifest that maps
 // each data file's execpath to its rlocationpath, ensuring correctness across the
 // execroot-to-runfiles boundary (where bazel-out/<config>/bin/ is stripped).
+//
+// Path separators are normalized to forward slashes so the regex and manifest
+// lookups work consistently on both Unix and Windows, where docker-compose may
+// emit backslash-separated absolute paths.
 func relativizePaths(yamlContent []byte, execrootPrefix string,
 	dataManifest map[string]string, outputRlocationDir string) []byte {
 
 	if execrootPrefix == "" || len(dataManifest) == 0 {
 		return yamlContent
 	}
-	execrootPrefix = filepath.Clean(execrootPrefix)
-	if !strings.HasSuffix(execrootPrefix, string(filepath.Separator)) {
-		execrootPrefix += string(filepath.Separator)
+	// Normalize prefix to forward slashes for cross-platform consistency
+	execrootPrefix = filepath.ToSlash(filepath.Clean(execrootPrefix))
+	if !strings.HasSuffix(execrootPrefix, "/") {
+		execrootPrefix += "/"
 	}
 	content := string(yamlContent)
+	// Build a regex that matches both / and \ as separators so we find paths
+	// regardless of how docker-compose wrote them (OS-dependent).
 	escapedPrefix := regexp.QuoteMeta(execrootPrefix)
+	escapedPrefix = strings.ReplaceAll(escapedPrefix, "/", `[/\\]`)
 	re := regexp.MustCompile(escapedPrefix + `([^:\s"'\n]*)`)
 	return []byte(re.ReplaceAllStringFunc(content, func(match string) string {
-		execpath := strings.TrimPrefix(match, execrootPrefix)
+		// Normalize the matched path to forward slashes before lookup
+		execpath := strings.TrimPrefix(filepath.ToSlash(match), execrootPrefix)
 
 		rlocationpath, ok := dataManifest[execpath]
 		if !ok {
@@ -52,7 +61,7 @@ func relativizePaths(yamlContent []byte, execrootPrefix string,
 			return match
 		}
 
-		relPath, err := filepath.Rel(outputRlocationDir, rlocationpath)
+		relPath, err := filepath.Rel(filepath.FromSlash(outputRlocationDir), filepath.FromSlash(rlocationpath))
 		if err != nil {
 			debugLog("Failed to relativize path %s: %v", execpath, err)
 			return match
@@ -77,15 +86,15 @@ func loadDataManifest(path string) (map[string]string, error) {
 }
 
 type Args struct {
-	DockerCompose      string
-	Output             string
-	OutputLock         string
-	ProjectName        string
-	DigestMode         string // "oci" or "docker"
-	DataManifest       string
+	DockerCompose       string
+	Output              string
+	OutputLock          string
+	ProjectName         string
+	DigestMode          string // "oci" or "docker"
+	DataManifest        string
 	OutputRlocationpath string
-	Files              []string
-	ImageManifests     []string
+	Files               []string
+	ImageManifests      []string
 }
 
 type ImageManifest struct {

--- a/docker_compose/private/tests/env_file/.env
+++ b/docker_compose/private/tests/env_file/.env
@@ -1,0 +1,1 @@
+MY_VAR=hello

--- a/docker_compose/private/tests/env_file/BUILD.bazel
+++ b/docker_compose/private/tests/env_file/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("//docker_compose:docker_compose_config.bzl", "docker_compose_config")
+load("//docker_compose:docker_compose_yaml.bzl", "docker_compose_yaml")
+
+docker_compose_yaml(
+    name = "yaml_env_file",
+    data = [".env"],
+    yamls = ["docker-compose.yaml"],
+)
+
+diff_test(
+    name = "yaml_env_file_diff_test",
+    file1 = "golden-yaml-env-file.yaml",
+    file2 = ":yaml_env_file",
+)
+
+docker_compose_yaml(
+    name = "starlark_env_file",
+    config = docker_compose_config(
+        services = {
+            "app": {
+                "environment": {"MY_VAR": "hello"},
+                "image": "nginx:latest",
+                "volumes": ["./.env:/app/.env:ro"],
+            },
+        },
+    ),
+    data = [".env"],
+)
+
+diff_test(
+    name = "starlark_env_file_diff_test",
+    file1 = "golden-starlark-env-file.yaml",
+    file2 = ":starlark_env_file",
+)

--- a/docker_compose/private/tests/env_file/docker-compose.yaml
+++ b/docker_compose/private/tests/env_file/docker-compose.yaml
@@ -1,0 +1,7 @@
+services:
+  app:
+    image: nginx:latest
+    env_file:
+      - .env
+    volumes:
+      - ./.env:/app/.env:ro

--- a/docker_compose/private/tests/env_file/golden-starlark-env-file.yaml
+++ b/docker_compose/private/tests/env_file/golden-starlark-env-file.yaml
@@ -1,0 +1,17 @@
+name: 00__docker_compose_private_tests_env_file__starlark_env_file
+services:
+  app:
+    environment:
+      MY_VAR: hello
+    image: nginx:latest
+    networks:
+      default: null
+    volumes:
+      - type: bind
+        source: ../.env
+        target: /app/.env
+        read_only: true
+        bind: {}
+networks:
+  default:
+    name: 00__docker_compose_private_tests_env_file__starlark_env_file_default

--- a/docker_compose/private/tests/env_file/golden-yaml-env-file.yaml
+++ b/docker_compose/private/tests/env_file/golden-yaml-env-file.yaml
@@ -1,0 +1,17 @@
+name: 00__docker_compose_private_tests_env_file__yaml_env_file
+services:
+  app:
+    environment:
+      MY_VAR: hello
+    image: nginx:latest
+    networks:
+      default: null
+    volumes:
+      - type: bind
+        source: ../.env
+        target: /app/.env
+        read_only: true
+        bind: {}
+networks:
+  default:
+    name: 00__docker_compose_private_tests_env_file__yaml_env_file_default

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,7 +24,9 @@ register_toolchains(
 
 `rules_docker_compose` provides Bazel rules for integrating Docker-Compose into your build and test workflows. These rules enable you to:
 
-- **Merge and validate docker-compose configurations** using the `docker_compose_yaml` rule, which combines multiple YAML files and ensures all referenced images have corresponding loader targets
+- **Merge and validate docker-compose configurations** using the `docker_compose_yaml` rule, which combines multiple YAML files and/or inline Starlark configuration, and ensures all referenced images have corresponding loader targets
+- **Define compose configurations in Starlark** using the `docker_compose_config` helper, which provides structured parameters mirroring the Compose Specification (services, networks, volumes, configs, secrets)
+- **Run docker-compose interactively** with the `docker_compose_binary` rule, which loads images and forwards arguments to docker-compose (e.g. `bazel run :compose -- up -d`)
 - **Run integration tests** with the `docker_compose_test` rule, which automatically starts services, waits for them to be ready, runs your test binary, and cleans up containers
 - **Verify image integrity** through automatically generated lock files that map image tags to content digests, ensuring the correct images are loaded at runtime
 


### PR DESCRIPTION
This rule allows you to `bazel run` docker-compose yamls managed by Bazel.